### PR TITLE
fix(ci): add security-events permission to semgrep job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,10 @@ jobs:
   semgrep:
     name: Semgrep Security Scan
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
     - uses: actions/checkout@v6
     


### PR DESCRIPTION
Add required permissions for the CodeQL upload-sarif action to
successfully upload SARIF files to GitHub's code scanning API.